### PR TITLE
Fixed line comment in zig config

### DIFF
--- a/crates/zed/src/languages/zig/config.toml
+++ b/crates/zed/src/languages/zig/config.toml
@@ -1,6 +1,6 @@
 name = "Zig"
 path_suffixes = ["zig"]
-line_comment = "// "
+line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
on zig i couldn't make work the "comment" keybingings , after a few search it seems its the only one of the language that is written like this, so i assume its a typo.
It fixed the problem
![Screenshot 2024-01-28 at 23 54 00](https://github.com/abelcha/zed/assets/6186996/d70810fe-be40-482b-a368-2a2a680737e7)

Haskell too but i'm not sure how the syntax work